### PR TITLE
Add unit tests for legal risk processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.3.2</version>
+    <relativePath/>
+  </parent>
+
   <groupId>com.bank</groupId>
   <artifactId>legalriskprocessor</artifactId>
   <version>1.0.0</version>
@@ -11,7 +19,6 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring.boot.version>3.3.2</spring.boot.version>
   </properties>
 
   <dependencies>
@@ -19,12 +26,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
-      <version>${spring.boot.version}</version>
     </dependency>
     <!-- In-memory event store implementation (simple) -->
     <dependency>
@@ -41,7 +46,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>${spring.boot.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -51,7 +55,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring.boot.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/com/bank/legalrisk/analysis/ptype/garage/LandRightsAnalyzerTest.java
+++ b/src/test/java/com/bank/legalrisk/analysis/ptype/garage/LandRightsAnalyzerTest.java
@@ -1,0 +1,59 @@
+package com.bank.legalrisk.analysis.ptype.garage;
+
+import com.bank.legalrisk.domain.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LandRightsAnalyzerTest {
+
+    @Test
+    void returnsCriticalRiskWhenLandRightsAreMissing() {
+        LandRightsAnalyzer analyzer = new LandRightsAnalyzer((type, years, region) -> 0);
+        EGRNData egrn = new EGRNData(
+                "77:01:0004012:1111",
+                PropertyType.GARAGE,
+                List.of(),
+                new PropertyHistory(List.of(), List.of()),
+                "",
+                null,
+                false,
+                "",
+                null,
+                null
+        );
+
+        List<RiskItem> risks = analyzer.analyze(egrn, "77");
+
+        assertEquals(1, risks.size());
+        RiskItem risk = risks.get(0);
+        assertEquals("LAND-NONE", risk.code());
+        assertEquals(RiskLevel.CRITICAL, risk.level());
+    }
+
+    @Test
+    void detectsShortLeaseAndHighMlScore() {
+        LandRightsAnalyzer analyzer = new LandRightsAnalyzer((type, years, region) -> 70);
+        EGRNData egrn = new EGRNData(
+                "77:01:0004012:2222",
+                PropertyType.GARAGE,
+                List.of(),
+                new PropertyHistory(List.of(), List.of()),
+                "LEASE",
+                3,
+                true,
+                "ACTIVE",
+                10,
+                2
+        );
+
+        List<RiskItem> risks = analyzer.analyze(egrn, "77");
+
+        assertEquals(2, risks.size());
+        assertTrue(risks.stream().anyMatch(r -> r.code().equals("LAND-LEASE-SHORT")));
+        assertTrue(risks.stream().anyMatch(r -> r.code().equals("LAND-ML-HIGH")));
+        assertTrue(risks.stream().allMatch(r -> r.level() == RiskLevel.HIGH));
+    }
+}

--- a/src/test/java/com/bank/legalrisk/core/LegalRiskProcessorTest.java
+++ b/src/test/java/com/bank/legalrisk/core/LegalRiskProcessorTest.java
@@ -1,0 +1,134 @@
+package com.bank.legalrisk.core;
+
+import com.bank.legalrisk.analysis.common.OwnershipAnalyzer;
+import com.bank.legalrisk.analysis.common.RegistrationAnalyzer;
+import com.bank.legalrisk.analysis.ptype.PropertyTypeAnalysisFactory;
+import com.bank.legalrisk.analysis.ptype.PropertyTypeAnalyzer;
+import com.bank.legalrisk.domain.*;
+import com.bank.legalrisk.events.InMemoryEventStore;
+import com.bank.legalrisk.events.LegalRiskEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LegalRiskProcessorTest {
+
+    @Test
+    void analyzeLegalRisksPublishesCommandsAndAggregatesResults() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+        StubPropertyAnalyzer analyzer = new StubPropertyAnalyzer();
+        PropertyTypeAnalysisFactory factory = new PropertyTypeAnalysisFactory() {
+            @Override
+            public PropertyTypeAnalyzer createAnalyzer(PropertyType type) {
+                return analyzer;
+            }
+        };
+        LegalRiskProcessor processor = new LegalRiskProcessor(
+                eventStore,
+                factory,
+                new OwnershipAnalyzer(),
+                new RegistrationAnalyzer()
+        );
+
+        String cadastralNumber = "77:01:0004012:1234";
+        LegalRiskAssessment assessment = processor.analyzeLegalRisks(cadastralNumber);
+
+        List<LegalRiskEvent> events = eventStore.loadByAggregateId("CAD:" + cadastralNumber);
+        assertEquals(2, events.size(), "Two command events should be published");
+        Set<String> types = events.stream().map(LegalRiskEvent::getType).collect(java.util.stream.Collectors.toSet());
+        assertEquals(Set.of("RosreestrDataRequested", "NBKIDataRequested"), types);
+        events.forEach(event -> assertEquals("CAD:" + cadastralNumber, event.getAggregateId()));
+        assertTrue(events.stream().allMatch(e -> e.getPayloadJson().contains(cadastralNumber)));
+
+        assertEquals(PropertyType.GARAGE, assessment.getPropertyType());
+        assertEquals(1, assessment.getCommonRisks().ownershipRisks.size(), "Ownership analyzer should add one risk item");
+        assertEquals(0, assessment.getCommonRisks().registrationRisks.size());
+        assertSame(assessment.getCommonRisks(), analyzer.lastCommon, "Common risks should be passed to the property analyzer");
+        assertEquals(cadastralNumber, analyzer.lastEgrn.cadastralNumber());
+
+        assertTrue(assessment.getPropertySpecificRisks() instanceof StubPropertySpecificRisks);
+        assertEquals(40, assessment.getPropertySpecificRisks().getSpecificRiskScore());
+        assertEquals(45, assessment.getIntegratedScore());
+        assertEquals(RiskLevel.HIGH, assessment.getRiskLevel());
+        assertEquals(1, assessment.getAllContractClauses().size());
+        assertEquals("STUB-CLAUSE", assessment.getAllContractClauses().get(0).code());
+        assertTrue(assessment.getRecommendations().contains("Провести углубленную юридическую проверку по перечню рисков."));
+    }
+
+    @Test
+    void requestCheckPersonVerificationPublishesEvent() {
+        InMemoryEventStore eventStore = new InMemoryEventStore();
+        PropertyTypeAnalysisFactory factory = new PropertyTypeAnalysisFactory() {
+            @Override
+            public PropertyTypeAnalyzer createAnalyzer(PropertyType type) {
+                return new StubPropertyAnalyzer();
+            }
+        };
+        LegalRiskProcessor processor = new LegalRiskProcessor(
+                eventStore,
+                factory,
+                new OwnershipAnalyzer(),
+                new RegistrationAnalyzer()
+        );
+
+        String ownerId = "owner-42";
+        String justification = "High risk owner";
+        PersonCheckResult result = processor.requestCheckPersonVerification(ownerId, justification);
+
+        assertEquals(ownerId, result.personId());
+        assertEquals("REQUESTED", result.status());
+        assertEquals(justification, result.justification());
+
+        List<LegalRiskEvent> events = eventStore.loadByAggregateId("PERSON:" + ownerId);
+        assertEquals(1, events.size(), "A single CheckPerson command should be recorded");
+        LegalRiskEvent event = events.get(0);
+        assertEquals("CheckPersonVerificationRequested", event.getType());
+        assertEquals("PERSON:" + ownerId, event.getAggregateId());
+        assertNotNull(event.getCorrelationId());
+        assertFalse(event.getCorrelationId().isBlank());
+        assertTrue(event.getPayloadJson().contains(ownerId));
+        assertTrue(event.getPayloadJson().contains(justification));
+    }
+
+    private static final class StubPropertyAnalyzer implements PropertyTypeAnalyzer {
+        private EGRNData lastEgrn;
+        private CommonRiskData lastCommon;
+
+        @Override
+        public PropertySpecificRisks analyzePropertySpecificRisks(EGRNData egrnData, CommonRiskData commonRisks) {
+            this.lastEgrn = egrnData;
+            this.lastCommon = commonRisks;
+            StubPropertySpecificRisks risks = new StubPropertySpecificRisks();
+            risks.specificRiskScore = 40;
+            risks.getClauses().addAll(generatePropertyTypeContractClauses(risks));
+            return risks;
+        }
+
+        @Override
+        public int calculatePropertyTypeScoring(PropertySpecificRisks risks) {
+            return 40;
+        }
+
+        @Override
+        public List<ContractClause> generatePropertyTypeContractClauses(PropertySpecificRisks risks) {
+            return List.of(new ContractClause("STUB-CLAUSE", "Test clause"));
+        }
+
+        @Override
+        public Map<RiskType, Double> getPropertyTypeWeights() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, Integer> getPropertySpecificPenalties() {
+            return Map.of();
+        }
+    }
+
+    private static final class StubPropertySpecificRisks extends PropertySpecificRisks {
+    }
+}


### PR DESCRIPTION
## Summary
- switch the Maven build to the Spring Boot starter parent for managed dependency versions
- add unit tests that verify LegalRiskProcessor publishes command events and aggregates results
- add LandRightsAnalyzer tests that cover missing land rights and high ML scoring scenarios

## Testing
- `mvn test` *(fails: unable to download org.springframework.boot:spring-boot-starter-parent due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c85ab91d44832d9560c0c5f79b0ade