### PR TITLE
Fix ML score variable shadowing in GSK analyzer

### DIFF
--- a/src/main/java/com/bank/legalrisk/analysis/ptype/garage/GSKAnalyzer.java
+++ b/src/main/java/com/bank/legalrisk/analysis/ptype/garage/GSKAnalyzer.java
@@ -37,10 +37,10 @@ public class GSKAnalyzer {
                         "Высокая доля должников в ГСК: " + share + "%", RiskLevel.HIGH, OffsetDateTime.now()));
             }
         }
-        int ml = ml.predictGskInstabilityScore(egrn.gskStatus(), egrn.gskMembers(), egrn.gskDebtors(), regionCode);
-        if (ml >= 60) {
+        int mlScore = ml.predictGskInstabilityScore(egrn.gskStatus(), egrn.gskMembers(), egrn.gskDebtors(), regionCode);
+        if (mlScore >= 60) {
             res.add(new RiskItem(RiskType.GSK, "GSK-ML-HIGH",
-                    "ML прогноз нестабильности ГСК: " + ml, RiskLevel.MEDIUM, OffsetDateTime.now()));
+                    "ML прогноз нестабильности ГСК: " + mlScore, RiskLevel.MEDIUM, OffsetDateTime.now()));
         }
         return res;
     }


### PR DESCRIPTION
## Summary
- avoid shadowing the GSK ML client with a primitive variable in the analyzer
- store the ML prediction in a clearly named `mlScore` variable and reuse it in the threshold check and message

## Testing
- mvn -q -DskipTests compile *(fails: cannot reach Maven Central to download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c8905f99d4832db6b6ad5e07b91af9